### PR TITLE
ovirt-log-collector: Remove the usage of logs.log_days sos option

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -821,7 +821,7 @@ fi
         cmd = partial(cmd, dump_volume_chains=dump_chains_option)
 
         if self.configuration.get('log_size'):
-            cmd = cmd(log_size='-k logs.log_days=1 --log-size={size}'.format(
+            cmd = cmd(log_size='--log-size={size}'.format(
                 size=self.configuration.get('log_size')
             ))
         else:
@@ -996,7 +996,7 @@ class ENGINEData(CollectorBase):
 
         if self.configuration.get("log_size"):
             opts.append(
-                "-k logs.log_days=1 --log-size=%s" %
+                "--log-size=%s" %
                 self.configuration.get('log_size')
             )
 
@@ -1122,7 +1122,7 @@ class PostgresData(CollectorBase):
             opt += '--ticket-number=%(ticket_number)s '
 
         if self.configuration.get("log_size"):
-            opt += '-k logs.log_days=1 --log-size=%(log_size)s '
+            opt += '--log-size=%(log_size)s '
 
         if sos.__version__.replace('.', '') < '30':
             opt += '--report '


### PR DESCRIPTION
sosreport logs plugin has removed the log_days option, thus it fails
to run if we attempt to use it.

RHBZ#2040402 ( https://bugzilla.redhat.com/2040402 )

Signed-off-by: Lev Veyde <lveyde@redhat.com>

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

* The use of the now deprecated log_days option of the logs plugin has been removed

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]