### PR TITLE
ovirt-log-collector: Fixed the usage message

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1734,9 +1734,9 @@ if __name__ == '__main__':
         )
 
     usage_string = "\n".join((
-        "Usage: %prog [options] list",
-        "       %prog [options] collect"
-    ))
+        "Usage: {prog} [options] list",
+        "       {prog} [options] collect"
+    )).format(prog="ovirt-log-collector")
 
     epilog_string = """\nReturn values:
     0: The program ran to completion with no errors.


### PR DESCRIPTION
Previously the utility showed the __main__.py as the utility name
in the help i.e. :

# ovirt-log-collector --help

Usage: __main__.py [options] list
       __main__.py [options] collect
...

This patch fixes this, so the correct utility name is shown:

# ovirt-log-collector --help

Usage: ovirt-log-collector [options] list
       ovirt-log-collector [options] collect
...

Signed-off-by: Lev Veyde <lveyde@redhat.com>

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

* The usage string that was fixed, so that help is shown correctly

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]