### PR TITLE
ovirt-log-collector: Clarified the --log-size option meaning

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1782,7 +1782,9 @@ to continue.
 
     parser.add_option(
         "", "--log-size", dest="log_size",
-        help="maximum log size to collect on each host in MiB",
+        help="maximum size of log to collect in MiB (NOTE: this is a "
+             "limit for the output of each individual sos plugin, not a "
+             "limit on a size of the total output from the host)",
         metavar="SIZE"
     )
 


### PR DESCRIPTION
Updated the help for the --log-size option, to avoid confusing the
limit on the individual log (per sos plugin), with the limit on
the total size of the log produced for the host, which is not
implemented in sos.

RHBZ#2081676 ( https://bugzilla.redhat.com/2081676 )

Signed-off-by: Lev Veyde <lveyde@redhat.com>

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

* Clarified the help for the --log-size option

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]