### PR TITLE
build: Added workaround for the issue caused by a CVE-2022-24765 fix

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,9 +1,18 @@
-.PHONY: installdeps srpm
+.PHONY: installdeps git_cfg_safe srpm
 
 installdeps:
 	dnf -y install git autoconf automake make gettext-devel gcc
 
-srpm: installdeps
+git_cfg_safe:
+	# Workaround for CVE-2022-24765 fix:
+	#
+	#	fatal: unsafe repository ('/path' is owned by someone else)
+	#
+	# Since copr build process first clones the repo, and then uses mock to run the build
+	#
+	git config --global --add safe.directory "$(shell pwd)"
+
+srpm: installdeps git_cfg_safe
 	$(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
 	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-log-collector.spec.in


### PR DESCRIPTION
Latest git seems to fail if the directory is not owned by the current
user.

Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Workaround for the issue caused by the git CVE fix

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]