### PR TITLE
Bz2081676

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1789,7 +1789,8 @@ to continue.
         help="maximum size of log to collect in MiB (NOTE: this is a "
              "limit for the output of each individual sos plugin, not a "
              "limit on a size of the total output from the host)",
-        metavar="SIZE"
+        metavar="SIZE",
+        type="int",
     )
 
     parser.add_option(

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1098,9 +1098,16 @@ class ENGINEData(CollectorBase):
             sos_plugins.append('ovirt_provider_ovn')
         self.configuration["sos_options"] = self.build_options()
         self.configuration["reports"] = ",".join(sos_plugins)
+        # We only want to enable the logs plugin if we gather all logs
+        # (disregarding the size limit) OR if the limit is set to 100 MB
+        # or more, which is the lower default limit of the logs plugin
+        # Reference:
+        # https://github.com/sosreport/sos/issues/1029
         if (
-            'logs.all_logs' in self.configuration['sos_options'] or
-            '--all-logs' in self.configuration['sos_options']
+               ('logs.all_logs' in self.configuration['sos_options'] or
+                '--all-logs' in self.configuration['sos_options']) or
+               ('log_size' in self.configuration.keys() and
+                self.configuration.get("log_size") >= 100)
         ):
             self.configuration['reports'] += ',logs'
         if 'ovirt_engine_dwh.sensitive_keys' in self._plugins:

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -775,25 +775,25 @@ VERSION=`/bin/rpm -q --qf '[%%{{VERSION}}]' \
     sos | /bin/sed 's/\\.//' | /bin/sed 's/\\..//'`;
 if [ "$VERSION" -ge "40" ]; then
     /usr/sbin/sos report {option} {log_size} {dump_volume_chains} --batch \
-        {all_logs} -o logs,%(reports)s,%(reports36)s
+        {all_logs} -o {logs}%(reports)s,%(reports36)s
 elif [ "$VERSION" -ge "36" ]; then
     /usr/sbin/sosreport {option} {log_size} {dump_volume_chains} --batch \
-        {all_logs} -o logs,%(reports)s,%(reports36)s
+        {all_logs} -o {logs}%(reports)s,%(reports36)s
 elif [ "$VERSION" -ge "35" ]; then
     /usr/sbin/sosreport {option} {log_size} {dump_volume_chains} --batch \
-        {all_logs} -o logs,%(reports)s,%(reports35)s
+        {all_logs} -o {logs}%(reports)s,%(reports35)s
 elif [ "$VERSION" -ge "34" ]; then
     /usr/sbin/sosreport {option} {log_size} --batch {all_logs} \
-        -o logs,%(reports)s,%(reports34)s
+        -o {logs}%(reports)s,%(reports34)s
 elif [ "$VERSION" -ge "33" ]; then
     /usr/sbin/sosreport {option} {log_size} --batch {all_logs} \
-        -o logs,%(reports)s,%(reports33)s
+        -o {logs}%(reports)s,%(reports33)s
 elif [ "$VERSION" -ge "32" ]; then
     /usr/sbin/sosreport {option} {log_size} --batch {all_logs} \
-        -o logs,%(reports)s,%(reports32)s
+        -o {logs}%(reports)s,%(reports32)s
 elif [ "$VERSION" -ge "30" ]; then
     /usr/sbin/sosreport {option} {log_size} --batch -k logs.all_logs=True \
-        -o logs,%(reports)s,%(reports3)s
+        -o {logs}%(reports)s,%(reports3)s
 elif [ "$VERSION" -ge "22" ]; then
     /usr/sbin/sosreport {option} {log_size} --batch -k general.all_logs=True \
         -o general,%(reports)s
@@ -832,14 +832,19 @@ fi
         cmd = partial(cmd, dump_volume_chains=dump_chains_option)
 
         if self.configuration.get('log_size'):
+            if self.configuration.get('log_size') >= 100:
+                logs = 'logs,'
+            else:
+                logs = ''
             cmd = cmd(
                 log_size='--log-size={size}'.format(
                     size=self.configuration.get('log_size')
                 ),
                 all_logs='',
+                logs=logs,
             )
         else:
-            cmd = cmd(log_size="", all_logs='--all-logs')
+            cmd = cmd(log_size="", all_logs='--all-logs', logs='logs,')
 
         return self.caller.call(cmd)
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1011,6 +1011,9 @@ class ENGINEData(CollectorBase):
                 "--ticket-number=%s" % self.configuration.get("ticket_number")
             )
 
+        if self.sos_version < '30':
+            opts.append('--report')
+
         if self.configuration.get("log_size"):
             opts.append(
                 "--log-size=%s" %


### PR DESCRIPTION
## Changes introduced with this PR

* Fixed the issue with the --log-size option that was previously silently ignored due to conflict with the --all-logs option

This PR adds the logic to handle various cases properly, i.e. removing the --all-logs option in case the --log-size option is supplied.

Also added logic to only enable the logs plugin in case --all-logs is used or if the --log-size value is equal or greater than 100 (MB). That is due to the way the logs plugin works.
( https://github.com/sosreport/sos/issues/1029 )

Also a verification was added to make sure that the value supplied to --log-size is integer, as it's the only type expected by sos.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]