### PR TITLE
Automation: fix build on el9

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
           mkdir -p ${PWD}/tmp.repos/BUILD
           dnf install -y --setopt=tsflags=nodocs autoconf automake gettext-devel git systemd make git rpm-build dnf-plugins-core python3-devel
-          dnf copr enable -y ovirt/ovirt-master-snapshot
+          dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9
           dnf install -y ovirt-release-master
           dnf install -y --setopt=tsflags=nodocs python3-pycodestyle python3-pyflakes
 


### PR DESCRIPTION
## Changes introduced with this PR

Fixes:
```
Error: It wasn't possible to enable this project.
Repository 'epel-9-x86_64' does not exist in project 'ovirt/ovirt-master-snapshot'.
```

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y